### PR TITLE
fix for unencrypted rooms.

### DIFF
--- a/hateheif.py
+++ b/hateheif.py
@@ -149,6 +149,7 @@ class HateHeifBot(Plugin):
 
         if content.url:  # content.url exists. File is not encrypted.
             data = await download_unencrypted_media(content.url, evt.client)
+            is_enc = False
         elif content.file:  # content.file exists. File is encrypted.
             data = await download_encrypted_media(content.file, evt.client)
             is_enc = True


### PR DESCRIPTION
unencrypted rooms fail because is_enc is undefined, resulting in "if is_enc" throwing an error on (old) line 168.